### PR TITLE
Enable line buffering for minimal output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ ENV USE_NO_CACHE 1
 EXPOSE 3306
 
 ENTRYPOINT ["/entrypoint.bash"]
-CMD ["/usr/local/bin/mysql-proxy", "--plugins=proxy", "--defaults-file=/etc/mp.conf", "-s", "/etc/debug.lua"]
+CMD ["stdbuf", "-oL", "-eL", "/usr/local/bin/mysql-proxy", "--plugins=proxy", "--defaults-file=/etc/mp.conf", "-s", "/etc/debug.lua"]


### PR DESCRIPTION
If there is minimal output from the profiler (which is AWESOME by the way, thanks!), it won't show up immediately - leading to some confusion.

This outputs as soon as any lines are outputted.